### PR TITLE
cannot resolve hostname エラーの解消

### DIFF
--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -1,5 +1,4 @@
 module(load="imuxsock") # provides support for local system logging
-module(load="imklog")   # provides kernel logging support
 
 # provides UDP syslog reception
 module(load="imudp")
@@ -8,8 +7,6 @@ input(type="imudp" port="514")
 # provides TCP syslog reception
 module(load="imtcp")
 input(type="imtcp" port="514")
-
-*.* @@remote-host:514
 
 # Output to stdout
 *.* action(type="omfwd" target="127.0.0.1" port="514" protocol="tcp"


### PR DESCRIPTION
rsyslogd: cannot resolve hostname 'remote-host': Invalid argument [v8.2001.0 try https://www.rsyslog.com/e/2027 ]